### PR TITLE
Pro 2832 git hash health check end point submit service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,14 @@
 target/
 .sonar
 .gradle
+.settings
+.project
+.classpath
 build/
 sonar-project.properties
+git.properties
 nbactions.xml
 /nbproject/
 nb-configuration.xml
 out/
+bin/

--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,18 @@ plugins {
   id 'org.springframework.boot' version '1.5.8.RELEASE'
   id 'org.owasp.dependencycheck' version '3.0.2'
   id 'com.github.ben-manes.versions' version '0.15.0'
+  id 'com.gorylenko.gradle-git-properties' version '1.4.21'
 }
 
 apply plugin: 'org.sonarqube'
 apply plugin: 'findbugs'
 apply plugin: 'jacoco'
+
+gitProperties {
+    keys = ['git.commit.id','git.commit.time']
+    dateFormat = "yyyy-MM-dd'T'HH:mmZ"
+    dateFormatTimeZone = "GMT"
+}
 
 group = 'uk.gov.hmcts.probate'
 version = "4.1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ apply plugin: 'findbugs'
 apply plugin: 'jacoco'
 
 gitProperties {
+    gitPropertiesDir = new File("${project.rootDir}/src/main/resources/uk/gov/hmcts/probate/services/submit")
     keys = ['git.commit.id','git.commit.time']
     dateFormat = "yyyy-MM-dd'T'HH:mmZ"
     dateFormatTimeZone = "GMT"

--- a/build.gradle
+++ b/build.gradle
@@ -115,11 +115,8 @@ dependencies {
   compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0.1'
   
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test' 
-//  testCompile group: 'org.springframework.security', name: 'spring-security-config', version: '4.2.3.RELEASE'
-//  testCompile group: 'org.springframework.security', name: 'spring-security-test', version: '4.2.3.RELEASE'
   testCompile group: 'org.springframework.security', name: 'spring-security-config'
   testCompile group: 'org.springframework.security', name: 'spring-security-test'
-  
 }
 
 compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -106,16 +106,20 @@ dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-mail'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-thymeleaf'
   compile group: 'org.springframework.retry', name: 'spring-retry'
-  compile group: 'org.springframework.security', name: 'spring-security-config'
-  
+
+    
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.logging
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: versions.logging
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.logging
   compile group: 'uk.gov.hmcts.auth.provider.service', name: 'service-token-generator-spring', version: '1.0.5'
   compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0.1'
   
-  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'  
+  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test' 
+//  testCompile group: 'org.springframework.security', name: 'spring-security-config', version: '4.2.3.RELEASE'
+//  testCompile group: 'org.springframework.security', name: 'spring-security-test', version: '4.2.3.RELEASE'
+  testCompile group: 'org.springframework.security', name: 'spring-security-config'
   testCompile group: 'org.springframework.security', name: 'spring-security-test'
+  
 }
 
 compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -106,14 +106,16 @@ dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-mail'
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-thymeleaf'
   compile group: 'org.springframework.retry', name: 'spring-retry'
-
+  compile group: 'org.springframework.security', name: 'spring-security-config'
+  
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.logging
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: versions.logging
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.logging
   compile group: 'uk.gov.hmcts.auth.provider.service', name: 'service-token-generator-spring', version: '1.0.5'
   compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0.1'
-
-  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
+  
+  testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'  
+  testCompile group: 'org.springframework.security', name: 'spring-security-test'
 }
 
 compileJava {

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/ApplicationConfig.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/ApplicationConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -14,6 +15,7 @@ import java.util.stream.Collectors;
 @Component
 @Configuration
 @ConfigurationProperties
+@PropertySource(value = "git.properties", ignoreResourceNotFound = true)
 public class ApplicationConfig {
     private List<Registry> registries = new ArrayList<>();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+management.info.git.mode=full

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 management.info.git.mode=full
+spring.info.git.location=classpath:uk/gov/hmcts/probate/services/submit/git.properties

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/services/GitCommitInfoEndpointTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/services/GitCommitInfoEndpointTest.java
@@ -18,12 +18,16 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import net.minidev.json.JSONObject;
+import net.minidev.json.parser.JSONParser;
+
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @TestPropertySource(properties = {"spring.info.git.location=classpath:uk/gov/hmcts/probate/services/submit/git-test.properties"})
 public class GitCommitInfoEndpointTest {
 
-	private static final String EXPECTED_INFO_ENDPOINT_JSON_RESPONSE = "{\"git\":{\"commit\":{\"time\":\"2018-05-23T13:59+1234\",\"id\":\"0773f129ad51c4a23a49fec96fec0888883443f6\"}}}";
+	private static final String EXPECTED_COMMIT_ID_INFO_RESPONSE = "0773f129ad51c4a23a49fec96fec0888883443f6";
+	private static final String EXPECTED_COMMIT_TIME_INFO_RESPONSE = "2018-05-23T13:59+1234";
 	
     @Autowired
     private WebApplicationContext context;
@@ -41,8 +45,15 @@ public class GitCommitInfoEndpointTest {
             throws Exception {
     	MvcResult result = this.mvc.perform(MockMvcRequestBuilders.get("/info"))
                 .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();	
-    	String actualInfoEndpointJsonResponse = result.getResponse().getContentAsString();   	
-    	assertEquals("Test response from info endpoint is correct.",EXPECTED_INFO_ENDPOINT_JSON_RESPONSE, actualInfoEndpointJsonResponse);
+    	String actualInfoEndpointJsonResponse = result.getResponse().getContentAsString(); 
+    	
+    	JSONParser jsonParser = new JSONParser(JSONParser.MODE_PERMISSIVE);
+    	JSONObject responseObj = (JSONObject) jsonParser.parse(actualInfoEndpointJsonResponse);
+    	JSONObject gitObject = (JSONObject) responseObj.get("git");
+    	JSONObject commitObject = (JSONObject) gitObject.get("commit");
+    	
+    	assertEquals("Test commit id response is correct.",EXPECTED_COMMIT_ID_INFO_RESPONSE, commitObject.getAsString("id"));
+    	assertEquals("Test commit time response is correct.",EXPECTED_COMMIT_TIME_INFO_RESPONSE, commitObject.getAsString("time"));
     }
 }
 

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/services/GitCommitInfoEndpointTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/services/GitCommitInfoEndpointTest.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.probate.services.submit.services;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.MetricsEndpoint;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@TestPropertySource(properties = {"spring.info.git.location=classpath:uk/gov/hmcts/probate/services/submit/git-test.properties"})
+public class GitCommitInfoEndpointTest {
+
+	private static final String EXPECTED_INFO_ENDPOINT_JSON_RESPONSE = "{\"git\":{\"commit\":{\"time\":\"2018-05-23T13:59+1234\",\"id\":\"0773f129ad51c4a23a49fec96fec0888883443f6\"}}}";
+	
+    @Autowired
+    private WebApplicationContext context;
+    
+    private MockMvc mvc;
+
+    @Before
+    public void setup() {
+        this.context.getBean(MetricsEndpoint.class).setEnabled(true);
+        this.mvc = MockMvcBuilders.webAppContextSetup(this.context).apply(SecurityMockMvcConfigurers.springSecurity()).build();
+    }
+    
+    @Test
+    public void testGitCommitInfoEndpoint()
+            throws Exception {
+    	MvcResult result = this.mvc.perform(MockMvcRequestBuilders.get("/info"))
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();	
+    	String actualInfoEndpointJsonResponse = result.getResponse().getContentAsString();   	
+    	assertEquals("Test response from info endpoint is correct.",EXPECTED_INFO_ENDPOINT_JSON_RESPONSE, actualInfoEndpointJsonResponse);
+    }
+}
+
+

--- a/src/test/resources/uk/gov/hmcts/probate/services/submit/git-test.properties
+++ b/src/test/resources/uk/gov/hmcts/probate/services/submit/git-test.properties
@@ -1,0 +1,2 @@
+git.commit.id=0773f129ad51c4a23a49fec96fec0888883443f6
+git.commit.time=2018-05-23T13:59+1234


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-2832

### Change description ###
Updates the /info endpoint for Spring Boot Actuator to display the last GIT commit id and commit time. This functionality is entirely configuration based. 

Further information regarding the implementation can be found from the GitHub gradle-git-properties page: https://github.com/n0mer/gradle-git-properties

Expected example JSON format for the endpoint /info is as follows: 
{"git":{"commit":{"time":"2018-05-24T09:37+0000","id":"71174840845617108cb6efc0e3d060bb4023678a"}}}

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
