### PR TITLE
Pro 2960 add dependencies to health endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ test.finalizedBy jacocoTestReport
 
 dependencyCheck {
   failBuildOnCVSS = System.getProperty('dependencyCheck.failBuild') == 'true' ? 0 : 11
-  suppressionFile = 'config/owasp/suppressions.xml'
+  suppressionFile = "${project.rootDir}/config/owasp/suppressions.xml"
   scanConfigurations = ['compile']
 }
 
@@ -144,10 +144,10 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.logging
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.6.0'
   compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0.1'
-
+  compile group: 'org.projectlombok', name: 'lombok', version: '1.16.18'
   
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test' 
-
+  
   testFunctionalCompile group: 'net.serenity-bdd', name: 'serenity-core', version: '1.5.2'
   testFunctionalCompile group: 'net.serenity-bdd', name: 'serenity-junit', version: '1.5.2'
   testFunctionalCompile group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: '1.5.2'

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthConfiguration.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.probate.services.submit.health;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class SubmitHealthConfiguration
+{	
+    @Autowired
+    private RestTemplate restTemplate;
+    
+    @Value("${services.coreCaseData.baseUrl}")
+    private String servicesCcdBaseUrl;
+
+    @Value("${services.persistence.baseUrl}")
+    private String servicesPersistenceBaseUrl;
+
+    @Bean
+    @ConditionalOnProperty(prefix = "services.coreCaseData", name = "enabled", matchIfMissing = true)
+    public SubmitHealthIndicator ccdServiceHealthIndicator() {
+    	return new SubmitHealthIndicator(servicesCcdBaseUrl, restTemplate); 
+    }  
+    
+    @Bean
+    public SubmitHealthIndicator persistenceServiceHealthIndicator() {
+    	return new SubmitHealthIndicator(servicesPersistenceBaseUrl, restTemplate); 
+    }    
+}

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicator.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.probate.services.submit.health;
+
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.UnknownHttpStatusCodeException;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@AllArgsConstructor
+public class SubmitHealthIndicator implements HealthIndicator {
+	
+	private final static String EXCEPTION_KEY = "exception";
+	private final static String MESSAGE_KEY = "message";
+    private final static String URL_KEY = "url";
+
+    private final String url;
+    private RestTemplate restTemplate;
+    
+    @Override
+    public Health health() {
+    	ResponseEntity<String> responseEntity;
+
+        try {
+            responseEntity = restTemplate.getForEntity(url + "/health", String.class);
+
+        } catch (ResourceAccessException rae) {
+            log.error(rae.getMessage(), rae);
+            return getHealthWithDownStatus(url, rae.getMessage(), "ResourceAccessException");
+        } catch (HttpStatusCodeException hsce) {
+            log.error(hsce.getMessage(), hsce);
+            return getHealthWithDownStatus(url, hsce.getMessage(),
+                    "HttpStatusCodeException - HTTP Status: " + hsce.getStatusCode().value());
+        } catch (UnknownHttpStatusCodeException uhsce) {
+            log.error(uhsce.getMessage(), uhsce);
+            return getHealthWithDownStatus(url, uhsce.getMessage(), "UnknownHttpStatusCodeException - " + uhsce.getStatusText());
+        }
+
+        if (responseEntity != null && !responseEntity.getStatusCode().equals(HttpStatus.OK)) {
+        	System.out.println("stage BAD");
+            return getHealthWithDownStatus(url, "HTTP Status code not 200", "HTTP Status: " + responseEntity.getStatusCodeValue());
+        }
+
+        return getHealthWithUpStatus(url);
+
+    }
+
+    private Health getHealthWithUpStatus(String url) {
+        return Health.up()
+                .withDetail(URL_KEY, url)
+                .withDetail(MESSAGE_KEY, "HTTP Status OK")
+                .build();
+    }
+
+    private Health getHealthWithDownStatus(String url, String message, String status) {
+        return Health.down()
+                .withDetail(URL_KEY, url)
+                .withDetail(MESSAGE_KEY, message)
+                .withDetail(EXCEPTION_KEY, status)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicator.java
@@ -43,7 +43,6 @@ public class SubmitHealthIndicator implements HealthIndicator {
         }
 
         if (responseEntity != null && !responseEntity.getStatusCode().equals(HttpStatus.OK)) {
-        	System.out.println("stage BAD");
             return getHealthWithDownStatus(url, "HTTP Status code not 200", "HTTP Status: " + responseEntity.getStatusCodeValue());
         }
 

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicator.java
@@ -16,7 +16,9 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 public class SubmitHealthIndicator implements HealthIndicator {
 	
-	private final static String ERROR_KEY = "error";
+	private final static String EXCEPTION_KEY = "exception";
+	private final static String MESSAGE_KEY = "message";
+    private final static String URL_KEY = "url";
 
     private final String url;
     private RestTemplate restTemplate;
@@ -26,35 +28,41 @@ public class SubmitHealthIndicator implements HealthIndicator {
     	ResponseEntity<String> responseEntity;
 
         try {
-        	log.debug("Attempting to access health endpoint: " + url + "/health");
             responseEntity = restTemplate.getForEntity(url + "/health", String.class);
+
         } catch (ResourceAccessException rae) {
             log.error(rae.getMessage(), rae);
-            return getHealthWithDownStatus("Connection failed with ResourceAccessException");
+            return getHealthWithDownStatus(url, rae.getMessage(), "ResourceAccessException");
         } catch (HttpStatusCodeException hsce) {
             log.error(hsce.getMessage(), hsce);
-            return getHealthWithDownStatus("HTTP Status: " + hsce.getStatusCode().value());
+            return getHealthWithDownStatus(url, hsce.getMessage(),
+                    "HttpStatusCodeException - HTTP Status: " + hsce.getStatusCode().value());
         } catch (UnknownHttpStatusCodeException uhsce) {
             log.error(uhsce.getMessage(), uhsce);
-            return getHealthWithDownStatus("Connection failed with UnknownHttpStatusCodeException");
+            return getHealthWithDownStatus(url, uhsce.getMessage(), "UnknownHttpStatusCodeException - " + uhsce.getStatusText());
         }
 
         if (responseEntity != null && !responseEntity.getStatusCode().equals(HttpStatus.OK)) {
-            return getHealthWithDownStatus("HTTP Status: " + responseEntity.getStatusCodeValue());
+        	System.out.println("stage BAD");
+            return getHealthWithDownStatus(url, "HTTP Status code not 200", "HTTP Status: " + responseEntity.getStatusCodeValue());
         }
 
-        return getHealthWithUpStatus();
+        return getHealthWithUpStatus(url);
 
     }
 
-    private Health getHealthWithUpStatus() {
+    private Health getHealthWithUpStatus(String url) {
         return Health.up()
+                .withDetail(URL_KEY, url)
+                .withDetail(MESSAGE_KEY, "HTTP Status OK")
                 .build();
     }
 
-    private Health getHealthWithDownStatus(String error) {
+    private Health getHealthWithDownStatus(String url, String message, String status) {
         return Health.down()
-                .withDetail(ERROR_KEY, error)
+                .withDetail(URL_KEY, url)
+                .withDetail(MESSAGE_KEY, message)
+                .withDetail(EXCEPTION_KEY, status)
                 .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -151,3 +151,4 @@
         Line 2 Bham
         Line 3 Bham
         PostCode Bham
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,8 +58,7 @@
       enabled: ${USE_CCD:false}
 
   auth.provider.service.client:
-    #baseUrl: http://localhost:4502
-    baseUrl: http://betadevaccidams2slb.reform.hmcts.net
+    baseUrl: http://localhost:4502
     microservice: 'probate_backend'
     key: dummyKey
     tokenTimeToLiveInSeconds: '900'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,3 @@
-management.security.enabled
-
 ---
   security:
     basic:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,14 @@
+management.security.enabled
+
 ---
+  security:
+    basic:
+      enabled: false
+
+  management:
+    security:
+      enabled: false
+  
   mail:
     username: localhost
     password: dummyKey
@@ -37,24 +47,27 @@
 
   services:
     persistence:
+      baseUrl: http://localhost:8282
       #service.url:  ${probate_persistence_service_url}:${probate_persistence_service_port}/formdata  #Till byron fixed side way communcation of app
-      formdata.url:  http://localhost:8282/formdata
+      formdata.url:  ${services.persistence.baseUrl}/formdata
       #service.url:  ${probate_persistence_service_url}:${probate_persistence_service_port}/submissions  #Till byron fixed side way communcation of app
-      submissions.url:  http://localhost:8282/submissions
-      sequenceNumber.url:  http://localhost:8282/sequence-number
+      submissions.url:  ${services.persistence.baseUrl}/submissions
+      sequenceNumber.url:  ${services.persistence.baseUrl}/sequence-number
 
     coreCaseData:
-      url: https://case-data-app.dev.ccd.reform.hmcts.net:4451/citizens/%s/jurisdictions/PROBATE/case-types/GrantOfRepresentation
+      baseUrl: https://case-data-app.dev.ccd.reform.hmcts.net:4451
+      url: ${services.coreCaseData.baseUrl}/citizens/%s/jurisdictions/PROBATE/case-types/GrantOfRepresentation
       enabled: ${USE_CCD:false}
 
   auth.provider.service.client:
-    baseUrl: http://localhost:4502
+    #baseUrl: http://localhost:4502
+    baseUrl: http://betadevaccidams2slb.reform.hmcts.net
     microservice: 'probate_backend'
     key: dummyKey
     tokenTimeToLiveInSeconds: '900'
 
   idam.s2s-auth.url: ${auth.provider.service.client.baseUrl}
-
+  
   ccd:
     probate:
       fullName: fullName

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicatorTest.java
@@ -21,7 +21,7 @@ import org.springframework.web.client.UnknownHttpStatusCodeException;
 @RunWith(MockitoJUnitRunner.class)
 public class SubmitHealthIndicatorTest {
 
-    private static final String URL = "http://gggg.com";
+    private static final String URL = "http://url.com";
 
     @Mock
     private RestTemplate mockRestTemplate;

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicatorTest.java
@@ -1,0 +1,100 @@
+package uk.gov.hmcts.probate.services.submit.health;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.UnknownHttpStatusCodeException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SubmitHealthIndicatorTest {
+
+    private static final String URL = "http://gggg.com";
+
+    @Mock
+    private RestTemplate mockRestTemplate;
+   
+    @Mock
+    private ResponseEntity<String> mockResponseEntity;
+    
+    private SubmitHealthIndicator submitHealthIndicator = new SubmitHealthIndicator(URL, mockRestTemplate);
+    
+    @Before
+    public void setUp() {
+    	submitHealthIndicator = new SubmitHealthIndicator(URL, mockRestTemplate);
+    }
+
+	@Test
+    public void shouldReturnStatusOfUpWhenHttpStatusIsOK() {
+        when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenReturn(mockResponseEntity);      
+        when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.OK);
+        Health health = submitHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(Status.UP));
+        assertThat(health.getDetails().get("url"), is(URL));
+    }
+
+	@Test
+    public void shouldReturnStatusOfDownWhenHttpStatusIsNotOK() {
+        when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenReturn(mockResponseEntity);
+        when(mockResponseEntity.getStatusCode()).thenReturn(HttpStatus.NO_CONTENT);
+        when(mockResponseEntity.getStatusCodeValue()).thenReturn(HttpStatus.NO_CONTENT.value());
+        Health health = submitHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(Status.DOWN));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is("HTTP Status code not 200"));
+        assertThat(health.getDetails().get("exception"), is("HTTP Status: 204"));
+    }
+
+    @Test
+    public void shouldReturnStatusOfDownWhenResourceAccessExceptionIsThrown() {
+        final String message = "EXCEPTION MESSAGE";
+        when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenThrow(new ResourceAccessException(message));
+
+        Health health = submitHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(Status.DOWN));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is(message));
+        assertThat(health.getDetails().get("exception"), is("ResourceAccessException"));
+    }
+
+    @Test
+    public void shouldReturnStatusOfDownWhenHttpStatusCodeExceptionIsThrown() {
+        when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        Health health = submitHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(Status.DOWN));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is("400 BAD_REQUEST"));
+        assertThat(health.getDetails().get("exception"), is("HttpStatusCodeException - HTTP Status: 400"));
+    }
+
+    @Test
+    public void shouldReturnStatusOfDownWhenUnknownHttpStatusCodeExceptionIsThrown() {
+        final String statusText = "status text";
+        when(mockRestTemplate.getForEntity(URL + "/health", String.class))
+                .thenThrow(new UnknownHttpStatusCodeException(1000, statusText, null, null, null));
+
+        Health health = submitHealthIndicator.health();
+
+        assertThat(health.getStatus(), is(Status.DOWN));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is("Unknown status code [1000] status text"));
+        assertThat(health.getDetails().get("exception"), is("UnknownHttpStatusCodeException - " + statusText));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicatorTest.java
@@ -43,7 +43,6 @@ public class SubmitHealthIndicatorTest {
         Health health = submitHealthIndicator.health();
 
         assertThat(health.getStatus(), is(Status.UP));
-        assertThat(health.getDetails().get("url"), is(URL));
     }
 
 	@Test
@@ -54,34 +53,26 @@ public class SubmitHealthIndicatorTest {
         Health health = submitHealthIndicator.health();
 
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("url"), is(URL));
-        assertThat(health.getDetails().get("message"), is("HTTP Status code not 200"));
-        assertThat(health.getDetails().get("exception"), is("HTTP Status: 204"));
+        assertThat(health.getDetails().get("error"), is("HTTP Status: 204"));
     }
 
     @Test
     public void shouldReturnStatusOfDownWhenResourceAccessExceptionIsThrown() {
         final String message = "EXCEPTION MESSAGE";
         when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenThrow(new ResourceAccessException(message));
-
         Health health = submitHealthIndicator.health();
-
+        
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("url"), is(URL));
-        assertThat(health.getDetails().get("message"), is(message));
-        assertThat(health.getDetails().get("exception"), is("ResourceAccessException"));
+        assertThat(health.getDetails().get("error"), is("Connection failed with ResourceAccessException"));
     }
 
     @Test
     public void shouldReturnStatusOfDownWhenHttpStatusCodeExceptionIsThrown() {
         when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
-
         Health health = submitHealthIndicator.health();
-
+        
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("url"), is(URL));
-        assertThat(health.getDetails().get("message"), is("400 BAD_REQUEST"));
-        assertThat(health.getDetails().get("exception"), is("HttpStatusCodeException - HTTP Status: 400"));
+        assertThat(health.getDetails().get("error"), is("HTTP Status: 400"));
     }
 
     @Test
@@ -89,12 +80,9 @@ public class SubmitHealthIndicatorTest {
         final String statusText = "status text";
         when(mockRestTemplate.getForEntity(URL + "/health", String.class))
                 .thenThrow(new UnknownHttpStatusCodeException(1000, statusText, null, null, null));
-
         Health health = submitHealthIndicator.health();
-
+        
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("url"), is(URL));
-        assertThat(health.getDetails().get("message"), is("Unknown status code [1000] status text"));
-        assertThat(health.getDetails().get("exception"), is("UnknownHttpStatusCodeException - " + statusText));
+        assertThat(health.getDetails().get("error"), is("Connection failed with UnknownHttpStatusCodeException"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicatorTest.java
@@ -29,7 +29,7 @@ public class SubmitHealthIndicatorTest {
     @Mock
     private ResponseEntity<String> mockResponseEntity;
     
-    private SubmitHealthIndicator submitHealthIndicator = new SubmitHealthIndicator(URL, mockRestTemplate);
+    private SubmitHealthIndicator submitHealthIndicator;
     
     @Before
     public void setUp() {

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicatorTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/health/SubmitHealthIndicatorTest.java
@@ -43,6 +43,7 @@ public class SubmitHealthIndicatorTest {
         Health health = submitHealthIndicator.health();
 
         assertThat(health.getStatus(), is(Status.UP));
+        assertThat(health.getDetails().get("url"), is(URL));
     }
 
 	@Test
@@ -53,26 +54,34 @@ public class SubmitHealthIndicatorTest {
         Health health = submitHealthIndicator.health();
 
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("error"), is("HTTP Status: 204"));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is("HTTP Status code not 200"));
+        assertThat(health.getDetails().get("exception"), is("HTTP Status: 204"));
     }
 
     @Test
     public void shouldReturnStatusOfDownWhenResourceAccessExceptionIsThrown() {
         final String message = "EXCEPTION MESSAGE";
         when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenThrow(new ResourceAccessException(message));
+
         Health health = submitHealthIndicator.health();
-        
+
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("error"), is("Connection failed with ResourceAccessException"));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is(message));
+        assertThat(health.getDetails().get("exception"), is("ResourceAccessException"));
     }
 
     @Test
     public void shouldReturnStatusOfDownWhenHttpStatusCodeExceptionIsThrown() {
         when(mockRestTemplate.getForEntity(URL + "/health", String.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
         Health health = submitHealthIndicator.health();
-        
+
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("error"), is("HTTP Status: 400"));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is("400 BAD_REQUEST"));
+        assertThat(health.getDetails().get("exception"), is("HttpStatusCodeException - HTTP Status: 400"));
     }
 
     @Test
@@ -80,9 +89,12 @@ public class SubmitHealthIndicatorTest {
         final String statusText = "status text";
         when(mockRestTemplate.getForEntity(URL + "/health", String.class))
                 .thenThrow(new UnknownHttpStatusCodeException(1000, statusText, null, null, null));
+
         Health health = submitHealthIndicator.health();
-        
+
         assertThat(health.getStatus(), is(Status.DOWN));
-        assertThat(health.getDetails().get("error"), is("Connection failed with UnknownHttpStatusCodeException"));
+        assertThat(health.getDetails().get("url"), is(URL));
+        assertThat(health.getDetails().get("message"), is("Unknown status code [1000] status text"));
+        assertThat(health.getDetails().get("exception"), is("UnknownHttpStatusCodeException - " + statusText));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-2960

### Change description ###
Updated to include two new health indicators.
- ccdService
- persistenceService

Please note because the application.yml "management: security: enabled" property is false all the health indicators are exposed in the endpoint. This means the endpoint currently reports on the following in addition to the custom health indicators above.
- mail  
- diskSpace  
- refreshScope
- hystrix
- uk.gov.hmcts.reform.authorisation.healthcheck.ServiceAuth (s2s)

Finally the ccdService health indicator is mapped to the application.yml "services: coreCaseData: enabled:" property which uses the environment variable ${USE_CCD:false}. If this is false the health indicator bean for ccdService will not get created and therefore the check will not take place.

Example JSON being returned: 
{"status":"UP","persistenceService":{"status":"UP"},"mail":{"status":"UP","location":"localhost:2525"},"diskSpace":{"status":"UP","total":499963170816,"free":422914011136,"threshold":10485760},"refreshScope":{"status":"UP"},"hystrix":{"status":"UP"},"uk.gov.hmcts.reform.authorisation.healthcheck.ServiceAuth":{"status":"UP"}}

If an error occurs you get:
{"status":"DOWN","persistenceService":{"status":"DOWN","error":"Connection failed with ResourceAccessException"},"mail":{"status":"UP","location":"localhost:2525"},"diskSpace":{"status":"UP","total":499963170816,"free":422912684032,"threshold":10485760},"refreshScope":{"status":"UP"},"hystrix":{"status":"UP"},"uk.gov.hmcts.reform.authorisation.healthcheck.ServiceAuth":{"status":"UP"}}

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
