### PR TITLE
PRO-3058: Added mutation testing (pitest)

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -34,6 +34,12 @@ withPipeline("java", product, component) {
   loadVaultSecrets(secrets)
   //enableSlackNotifications('#probate-jenkins')
   after('test') {
+    try {
+        sh './gradlew pitest'
+    } finally {
+        steps.archiveArtifacts "build/reports/pitest/**/*.*"
+    }
+
     junit 'build/test-results/test/**/*.xml'
     archiveArtifacts 'build/reports/tests/test/index.html'
     publishHTML target: [

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ plugins {
   id 'org.owasp.dependencycheck' version '3.2.1'
   id 'com.github.ben-manes.versions' version '0.15.0'
   id 'com.gorylenko.gradle-git-properties' version '1.4.21'
+  id 'info.solidsoft.pitest' version '1.3.0'
 }
 
 apply plugin: 'org.sonarqube'
@@ -65,6 +66,8 @@ sonarqube {
     property "sonar.projectName", "probate :: submit service"
     property "sonar.jacoco.reportPath", "${project.buildDir}/jacoco/test.exec"
     property "sonar.host.url", "https://sonar.reform.hmcts.net/"
+    property "sonar.pitest.mode", "reuseReport"
+    property "sonar.pitest.reportsDirectory", "build/reports/pitest"
   }
 }
 
@@ -138,6 +141,14 @@ jacocoTestReport {
     }
 }
 
+pitest {
+  targetClasses = ['uk.gov.hmcts.probate.*']
+  threads = 4
+  outputFormats = ['XML', 'HTML']
+  timestampedReports = false
+  mutationThreshold = 50
+}
+
 repositories {
   mavenLocal()
   maven { url "https://dl.bintray.com/hmcts/hmcts-maven" }
@@ -171,6 +182,10 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.6.0'
   compile group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0.1'
   compile group: 'org.projectlombok', name: 'lombok', version: '1.16.18'
+
+  compile group: 'org.pitest', name: 'pitest', version: '1.3.2'
+  compile 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.3.0'
+  compile 'org.codehaus.sonar-plugins:sonar-pitest-plugin:0.5'
   
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test' 
   

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/services/GitCommitInfoEndpointTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/services/GitCommitInfoEndpointTest.java
@@ -1,50 +1,40 @@
 package uk.gov.hmcts.probate.services.submit.services;
 
-import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-
-import net.minidev.json.JSONObject;
-import net.minidev.json.parser.JSONParser;
 
 @RunWith(SpringRunner.class)
-@Configuration
-@TestPropertySource(properties = {"spring.info.git.location=classpath:uk/gov/hmcts/probate/services/submit/git-test.properties"})
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+    "spring.info.git.location=classpath:uk/gov/hmcts/probate/services/submit/git-test.properties"})
 public class GitCommitInfoEndpointTest {
 
-	private static final String EXPECTED_COMMIT_ID_INFO_RESPONSE = "0773f129ad51c4a23a49fec96fec0888883443f6";
-	private static final String EXPECTED_COMMIT_TIME_INFO_RESPONSE = "2018-05-23T13:59+1234";
-	
-    private MockMvc mockMvc;
-    
-    @Test
-    public void testGitCommitInfoEndpoint()
-            throws Exception {
-    	
-    	try { 
-	    	MvcResult result = this.mockMvc.perform(get("/info"))
-	                .andExpect(status().isOk()).andReturn();	
-	    	String actualInfoEndpointJsonResponse = result.getResponse().getContentAsString(); 
-	    	
-	    	JSONParser jsonParser = new JSONParser(JSONParser.MODE_PERMISSIVE);
-	    	JSONObject responseObj = (JSONObject) jsonParser.parse(actualInfoEndpointJsonResponse);
-	    	JSONObject gitObject = (JSONObject) responseObj.get("git");
-	    	JSONObject commitObject = (JSONObject) gitObject.get("commit");
-	    	
-	    	assertEquals("Test commit id response is correct.",EXPECTED_COMMIT_ID_INFO_RESPONSE, commitObject.getAsString("id"));
-	    	assertEquals("Test commit time response is correct.",EXPECTED_COMMIT_TIME_INFO_RESPONSE, commitObject.getAsString("time"));
-	    	
-    	} catch ( Exception e ) {
-    		e.printStackTrace();
-    	}
-    }
-}
+  private static final String EXPECTED_COMMIT_ID_INFO_RESPONSE = "0773f12";
+  private static final String EXPECTED_COMMIT_TIME_INFO_RESPONSE = "2018-05-23T13:59+1234";
 
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private SubmitService submitService;
+
+  @Test
+  public void shouldGetGitCommitInfoEndpoint() throws Exception {
+    mockMvc.perform(get("/info"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.git.commit.id").value(EXPECTED_COMMIT_ID_INFO_RESPONSE))
+        .andExpect(jsonPath("$.git.commit.time").value(EXPECTED_COMMIT_TIME_INFO_RESPONSE));
+  }
+}

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/services/SequenceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/services/SequenceServiceTest.java
@@ -1,14 +1,20 @@
 package uk.gov.hmcts.probate.services.submit.services;
 
-import java.util.Map;
-import java.util.Properties;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.Properties;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -16,13 +22,6 @@ import org.springframework.mail.javamail.JavaMailSenderImpl;
 import uk.gov.hmcts.probate.services.submit.Registry;
 import uk.gov.hmcts.probate.services.submit.clients.PersistenceClient;
 import uk.gov.hmcts.probate.services.submit.utils.TestUtils;
-
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SequenceServiceTest {
@@ -38,7 +37,7 @@ public class SequenceServiceTest {
     private long submissionReference;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         MockitoAnnotations.initMocks(this);
         submitService = mock(SubmitService.class);
         persistenceClient = mock(PersistenceClient.class);
@@ -47,11 +46,7 @@ public class SequenceServiceTest {
         mapper = new ObjectMapper();
         testUtils = new TestUtils();
         sequenceService = new SequenceService(registryMap, persistenceClient, mailSender, mapper);
-        int mockRegistryCounter = 1;
         submissionReference = 1234;
-        when(registryMap.size()).thenReturn(2);
-        when(registryMap.get(mockRegistryCounter % registryMap.size()))
-                .thenReturn(mockRegistry);
     }
 
     @Test
@@ -69,6 +64,9 @@ public class SequenceServiceTest {
 
     @Test
     public void populateRegistrySubmitData() {
+        when(registryMap.size()).thenReturn(2);
+        when(registryMap.get(anyInt())).thenReturn(mockRegistry);
+
         JsonNode registryData = testUtils.getJsonNodeFromFile("registryDataSubmit.json");
         when(sequenceService.identifyNextRegistry()).thenReturn(mockRegistry);
         when(mockRegistry.capitalizeRegistryName()).thenReturn("Oxford");
@@ -103,7 +101,9 @@ public class SequenceServiceTest {
 
     @Test
     public void identifyNextRegistry() {
-        when(sequenceService.identifyNextRegistry()).thenReturn(mockRegistry);
+        when(registryMap.size()).thenReturn(2);
+        when(registryMap.get(anyInt())).thenReturn(mockRegistry);
+
         Registry result = sequenceService.identifyNextRegistry();
         assertThat(result, is(equalTo(mockRegistry)));
     }


### PR DESCRIPTION
### Change description ###
- Added mutation testing, which runs after the tests on jenkins.
- Mutation testing results are then used by sonar (analysis -> mutation)
- Fixed GitCommitInfoEndpointTest - this was not working before, just catching the nullpointer exception which was caused by MockMvc not being correct wired
- Fixed identifyNextRegistry test - as it was not testing the logic (pitest complained).
- Also modified populateRegistrySubmitData because both populateRegistrySubmitData and identifyNextRegistry use the counter variable which cause the tests effect each other when run it different orders (ie the tests need to be fully independant.)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
