### PR TITLE
[PREVIEW] PRO-3790: Fix to allow case to be updated after submit service is down (SUBMIT SERVICE).

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/services/submit/clients/CoreCaseDataClient.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/clients/CoreCaseDataClient.java
@@ -94,8 +94,8 @@ public class CoreCaseDataClient {
             logger.info("Found case in CCD - caseId: {}, caseState: {}", ccdCaseResponse.getCaseId(), ccdCaseResponse.getState());
             return Optional.of(ccdCaseResponse);
         } catch (HttpClientErrorException e) {
-            logger.info("Exception while getting a case from CCD", e);
-            logger.info(STATUS_CODE_LOG, e.getStatusText());
+            logger.error("Exception while getting a case from CCD", e);
+            logger.error(STATUS_CODE_LOG, e.getStatusText());
             throw new HttpClientErrorException(e.getStatusCode());
         }
     }
@@ -123,8 +123,8 @@ public class CoreCaseDataClient {
                     .exchange(url, HttpMethod.GET, request, JsonNode.class);
             return response.getBody().get(TOKEN_RESOURCE);
         } catch (HttpClientErrorException e) {
-            logger.info("Exception while getting an event token from CCD", e);
-            logger.info(STATUS_CODE_LOG, e.getStatusText());
+            logger.error("Exception while getting an event token from CCD", e);
+            logger.error(STATUS_CODE_LOG, e.getStatusText());
             throw new HttpClientErrorException(e.getStatusCode());
         }
     }
@@ -149,8 +149,8 @@ public class CoreCaseDataClient {
             logResponse(response);
             return response.getBody();
         } catch (HttpClientErrorException e) {
-            logger.info("Exception while saving case to CCD", e);
-            logger.info(STATUS_CODE_LOG, e.getStatusText());
+            logger.error("Exception while saving case to CCD", e);
+            logger.error(STATUS_CODE_LOG, e.getStatusText());
             throw new HttpClientErrorException(e.getStatusCode());
         }
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-3790

### Change description ###
PR created to allow testing of the changes from the PA frontend application for allowing the CCD case to be successfully updated after the submit service has been down. Please see PRO-3790 for more details along with the original PR fix for the frontend https://github.com/hmcts/probate-frontend/pull/371.

To provide a change for this PR to be created, I've updated the logging in CoreCaseDataClient which should have been using logger.error instead of logger.info when logging exceptions.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
