### PR TITLE
PRO-5546: Caveat payment callback

### DIFF
--- a/src/main/java/uk/gov/hmcts/probate/security/SecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/probate/security/SecurityConfiguration.java
@@ -33,7 +33,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers("/drafts/**")
                 .antMatchers("/submissions/**")
                 .antMatchers("/payments/**")
-                .antMatchers("/ccd-case-payments/**")
+                .antMatchers("/ccd-case-update/**")
                 .and()
                 .addFilter(filter)
                 .csrf().disable()

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/controllers/v2/CasesController.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/controllers/v2/CasesController.java
@@ -8,10 +8,17 @@ import io.swagger.annotations.SwaggerDefinition;
 import io.swagger.annotations.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import static org.springframework.http.HttpStatus.OK;
+
+import javax.validation.Valid;
+
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,8 +35,7 @@ public class CasesController {
 
     private final CasesService casesService;
 
-
-    @ApiOperation(value = "Get case to CCD", notes = "Get case to CCD")
+    @ApiOperation(value = "Get case to CCD using session identifier", notes = "Get case to CCD")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Case retrieval from CCD successful"),
             @ApiResponse(code = 400, message = "Case retrieval from CCD successful")
@@ -42,4 +48,15 @@ public class CasesController {
         return ResponseEntity.ok(casesService.getCase(applicationId.toLowerCase(), caseType));
     }
 
+    @ApiOperation(value = "Get case to CCD using case Id", notes = "Get case to CCD")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Case retrieval from CCD successful"),
+            @ApiResponse(code = 400, message = "Case retrieval from CCD successful")
+    })
+    @GetMapping(path = "/cases/ccd/{caseId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public ResponseEntity<ProbateCaseDetails> getCase(@PathVariable("caseId") String caseId) {
+        log.info("Retrieving case using application id: {}", caseId.toLowerCase());
+        return ResponseEntity.ok(casesService.getCaseById(caseId.toLowerCase()));
+    }
 }

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/controllers/v2/CasesController.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/controllers/v2/CasesController.java
@@ -53,9 +53,9 @@ public class CasesController {
             @ApiResponse(code = 200, message = "Case retrieval from CCD successful"),
             @ApiResponse(code = 400, message = "Case retrieval from CCD successful")
     })
-    @GetMapping(path = "/cases/ccd/{caseId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(path = "/cases", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public ResponseEntity<ProbateCaseDetails> getCase(@PathVariable("caseId") String caseId) {
+    public ResponseEntity<ProbateCaseDetails> getCase(@RequestParam(name="caseId") String caseId) {
         log.info("Retrieving case using application id: {}", caseId.toLowerCase());
         return ResponseEntity.ok(casesService.getCaseById(caseId.toLowerCase()));
     }

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/controllers/v2/PaymentsController.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/controllers/v2/PaymentsController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.probate.services.submit.services.PaymentsService;
+import uk.gov.hmcts.reform.probate.model.cases.CaseData;
 import uk.gov.hmcts.reform.probate.model.cases.CaseType;
 import uk.gov.hmcts.reform.probate.model.cases.ProbateCaseDetails;
 import uk.gov.hmcts.reform.probate.model.cases.ProbatePaymentDetails;
@@ -56,11 +57,11 @@ public class PaymentsController {
         return new ResponseEntity(paymentsService.createCase(applicationId.toLowerCase(), probateCaseDetails), OK);
     }
 
-    @PostMapping(path = "/ccd-case-payments/{caseId}", consumes = MediaType.APPLICATION_JSON_VALUE,
+    @PostMapping(path = "/ccd-case-update/{caseId}", consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
-    public ResponseEntity<ProbateCaseDetails> updatePaymentByCaseId(@PathVariable("caseId") String caseId,
-                                                                    @Valid @RequestBody ProbatePaymentDetails probatePaymentDetails) {
-        return new ResponseEntity(paymentsService.updatePaymentByCaseId(caseId, probatePaymentDetails), OK);
+    public ResponseEntity<ProbateCaseDetails> updateCaseByCaseId(@PathVariable("caseId") String caseId,
+                                                                    @RequestBody ProbateCaseDetails probateCaseDetails) {
+        return new ResponseEntity(paymentsService.updateCaseByCaseId(caseId, probateCaseDetails), OK);
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/core/CasesServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/core/CasesServiceImpl.java
@@ -30,4 +30,13 @@ public class CasesServiceImpl implements CasesService {
                 .findCase(searchField, caseType, securityDTO);
         return caseResponseOptional.orElseThrow(CaseNotFoundException::new);
     }
+
+    @Override
+    public ProbateCaseDetails getCaseById(String caseId) {
+        log.info("Getting case by caseId: {}", caseId);
+        SecurityDTO securityDTO = securityUtils.getSecurityDTO();
+        Optional<ProbateCaseDetails> caseResponseOptional = coreCaseDataService
+                .findCaseById(caseId, securityDTO);
+        return caseResponseOptional.orElseThrow(CaseNotFoundException::new);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/services/CasesService.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/services/CasesService.java
@@ -6,4 +6,6 @@ import uk.gov.hmcts.reform.probate.model.cases.ProbateCaseDetails;
 public interface CasesService {
 
     ProbateCaseDetails getCase(String searchField, CaseType caseType);
+
+    ProbateCaseDetails getCaseById(String caseId);
 }

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/services/PaymentsService.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/services/PaymentsService.java
@@ -9,5 +9,5 @@ public interface PaymentsService {
 
     ProbateCaseDetails createCase(String searchField, ProbateCaseDetails probateCaseDetails);
 
-    ProbateCaseDetails updatePaymentByCaseId(String caseId, ProbatePaymentDetails paymentUpdateRequest);
+    ProbateCaseDetails updateCaseByCaseId(String caseId, ProbateCaseDetails probateUpdateRequest);
 }

--- a/src/pactTest/resources/json/intestacyGrantOfRepresentation_full_submission.json
+++ b/src/pactTest/resources/json/intestacyGrantOfRepresentation_full_submission.json
@@ -55,6 +55,6 @@
   },
   "caseInfo": {
     "caseId": "12323213323",
-    "state": "Draft"
+    "state": "PAAppCreated"
   }
 }

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/controllers/v2/CasesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/controllers/v2/CasesControllerTest.java
@@ -27,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class CasesControllerTest {
 
     private static final String CASES_URL = "/cases";
+    private static final String CASES_CCD_URL = "/cases/ccd";
     private static final String EMAIL_ADDRESS = "test@test.com";
     private static final String CASE_ID = "1343242352";
     private static final String DRAFT = "Draft";
@@ -55,5 +56,22 @@ public class CasesControllerTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
         verify(casesService, times(1)).getCase(EMAIL_ADDRESS, CaseType.GRANT_OF_REPRESENTATION);
+    }
+    
+    @Test
+    public void shouldGetCaseByIdForIntestacyGrantOfRepresentation() throws Exception {
+        String json = TestUtils.getJSONFromFile("files/v2/intestacyGrantOfRepresentation.json");
+        CaseData grantOfRepresentation = objectMapper.readValue(json, CaseData.class);
+        CaseInfo caseInfo = new CaseInfo();
+        caseInfo.setCaseId(CASE_ID);
+        caseInfo.setState(DRAFT);
+        ProbateCaseDetails caseResponse = ProbateCaseDetails.builder().caseInfo(caseInfo).caseData(grantOfRepresentation).build();
+        when(casesService.getCaseById(CASE_ID)).thenReturn(caseResponse);
+
+        mockMvc.perform(get(CASES_CCD_URL + "/" + CASE_ID)
+                .param("caseId", CASE_ID)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+        verify(casesService, times(1)).getCaseById(CASE_ID);
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/controllers/v2/CasesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/controllers/v2/CasesControllerTest.java
@@ -27,7 +27,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class CasesControllerTest {
 
     private static final String CASES_URL = "/cases";
-    private static final String CASES_CCD_URL = "/cases/ccd";
     private static final String EMAIL_ADDRESS = "test@test.com";
     private static final String CASE_ID = "1343242352";
     private static final String DRAFT = "Draft";
@@ -68,7 +67,7 @@ public class CasesControllerTest {
         ProbateCaseDetails caseResponse = ProbateCaseDetails.builder().caseInfo(caseInfo).caseData(grantOfRepresentation).build();
         when(casesService.getCaseById(CASE_ID)).thenReturn(caseResponse);
 
-        mockMvc.perform(get(CASES_CCD_URL + "/" + CASE_ID)
+        mockMvc.perform(get(CASES_URL)
                 .param("caseId", CASE_ID)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/controllers/v2/PaymentsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/controllers/v2/PaymentsControllerTest.java
@@ -29,7 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class PaymentsControllerTest {
 
     private static final String PAYMENTS_URL = "/payments";
-    private static final String UPDATE_PAYMENTS_URL = "/ccd-case-payments";
+    private static final String UPDATE_CASE_URL = "/ccd-case-update";
     private static final String EMAIL_ADDRESS = "test@test.com";
     private static final String CASE_ID = "1343242352";
     private static final String APPLICATION_CREATED = "PAAppCreated";
@@ -46,17 +46,14 @@ public class PaymentsControllerTest {
 
     @Test
     public void shouldUpdatePaymentByCaseId() throws Exception {
-        String json = TestUtils.getJSONFromFile("files/v2/payments.json");
-        CasePayment casePayment = objectMapper.readValue(json, CasePayment.class);
-        ProbatePaymentDetails paymentUpdateRequest = ProbatePaymentDetails.builder()
-            .payment(casePayment)
-            .build();
+        String json = TestUtils.getJSONFromFile("files/v2/intestacyGrantOfRepresentation_caseDetails.json");
+        ProbateCaseDetails caseDetailsRequest = objectMapper.readValue(json, ProbateCaseDetails.class);
 
-        mockMvc.perform(post(UPDATE_PAYMENTS_URL + "/" + CASE_ID)
-            .content(objectMapper.writeValueAsString(paymentUpdateRequest))
+        mockMvc.perform(post(UPDATE_CASE_URL + "/" + CASE_ID)
+            .content(objectMapper.writeValueAsString(caseDetailsRequest))
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
-        verify(paymentsService).updatePaymentByCaseId(eq(CASE_ID), eq(paymentUpdateRequest));
+        verify(paymentsService).updateCaseByCaseId(eq(CASE_ID), eq(caseDetailsRequest));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/controllers/v2/SubmissionsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/controllers/v2/SubmissionsControllerTest.java
@@ -84,7 +84,6 @@ public class SubmissionsControllerTest {
                 .andExpect(status().isBadRequest())
                 .andReturn();
         String content = result.getResponse().getContentAsString();
-        System.out.println(content);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/core/CasesServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/core/CasesServiceImplTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 public class CasesServiceImplTest {
 
     private static final String EMAIL_ADDRESS = "test@test.com";
-
+    private static final String CASE_ID = "1343242352";
     private static final CaseType CASE_TYPE = CaseType.GRANT_OF_REPRESENTATION;
 
     @Mock
@@ -47,5 +47,19 @@ public class CasesServiceImplTest {
         assertThat(caseResponse, equalTo(caseResponseOptional.get()));
         verify(securityUtils, times(1)).getSecurityDTO();
         verify(coreCaseDataService, times(1)).findCase(EMAIL_ADDRESS, CASE_TYPE, securityDTO);
+    }
+    
+    @Test
+    public void shouldGetCaseById() {
+        SecurityDTO securityDTO = SecurityDTO.builder().build();
+        Optional<ProbateCaseDetails> caseResponseOptional = Optional.of(ProbateCaseDetails.builder().build());
+        when(securityUtils.getSecurityDTO()).thenReturn(securityDTO);
+        when(coreCaseDataService.findCaseById(CASE_ID, securityDTO)).thenReturn(caseResponseOptional);
+
+        ProbateCaseDetails caseResponse = casesService.getCaseById(CASE_ID);
+
+        assertThat(caseResponse, equalTo(caseResponseOptional.get()));
+        verify(securityUtils, times(1)).getSecurityDTO();
+        verify(coreCaseDataService, times(1)).findCaseById(CASE_ID, securityDTO);
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/core/PaymentServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/core/PaymentServiceImplTest.java
@@ -78,6 +78,8 @@ public class PaymentServiceImplTest {
 
     private ProbatePaymentDetails paymentUpdateRequest;
 
+    private ProbateCaseDetails probateCaseDetailsRequest;
+
     @Before
     public void setUp() {
         payment = new CasePayment();
@@ -93,15 +95,13 @@ public class PaymentServiceImplTest {
             .build();
         caseData = new GrantOfRepresentationData();
         caseData.setPayments(Lists.newArrayList(CollectionMember.<CasePayment>builder()
-            .value(CasePayment.builder()
-                .status(PaymentStatus.SUCCESS)
-                .build())
-            .build()));
+                .value(payment)
+                .build()));
         caseInfo = new CaseInfo();
         caseInfo.setCaseId(CASE_ID);
         caseInfo.setState(STATE);
+        probateCaseDetailsRequest = ProbateCaseDetails.builder().caseData(caseData).caseInfo(caseInfo).build();
         caseResponse = ProbateCaseDetails.builder().caseData(caseData).caseInfo(caseInfo).build();
-
         when(eventFactory.getCaseEvents(CaseType.GRANT_OF_REPRESENTATION)).thenReturn(CaseEvents.builder()
             .createCaseApplicationEventId(GOP_CREATE_APPLICATION)
             .createCaseEventId(GOP_CREATE_CASE)
@@ -210,9 +210,8 @@ public class PaymentServiceImplTest {
         paymentService.addPaymentToCase(APPLICANT_EMAIL, paymentUpdateRequest);
     }
 
-
     @Test
-    public void shouldUpdatePaymentByCaseIdAndIsSuccess() {
+    public void shouldUpdateCaseByCaseIdAndIsSuccess() {
         when(mockSecurityUtils.getSecurityDTO()).thenReturn(securityDTO);
         when(mockCoreCaseDataService.findCaseById(CASE_ID, securityDTO))
             .thenReturn(Optional.of(caseResponse));
@@ -220,7 +219,7 @@ public class PaymentServiceImplTest {
             eq(GOP_CREATE_CASE), eq(securityDTO)))
             .thenReturn(caseResponse);
 
-        ProbateCaseDetails actualCaseResponse = paymentService.updatePaymentByCaseId(CASE_ID, paymentUpdateRequest);
+        ProbateCaseDetails actualCaseResponse = paymentService.updateCaseByCaseId(CASE_ID, probateCaseDetailsRequest);
 
         assertThat(actualCaseResponse, equalTo(actualCaseResponse));
         verify(mockSecurityUtils).getSecurityDTO();
@@ -236,7 +235,7 @@ public class PaymentServiceImplTest {
         when(mockCoreCaseDataService.findCaseById(CASE_ID, securityDTO))
             .thenReturn(Optional.of(caseResponse));
 
-        ProbateCaseDetails actualCaseResponse = paymentService.updatePaymentByCaseId(CASE_ID, paymentUpdateRequest);
+        ProbateCaseDetails actualCaseResponse = paymentService.updateCaseByCaseId(CASE_ID, probateCaseDetailsRequest);
 
         assertThat(actualCaseResponse, equalTo(actualCaseResponse));
         verify(mockSecurityUtils).getSecurityDTO();

--- a/src/test/resources/files/v2/intestacyGrantOfRepresentation_caseDetails.json
+++ b/src/test/resources/files/v2/intestacyGrantOfRepresentation_caseDetails.json
@@ -1,0 +1,73 @@
+{
+	  "caseData": {
+	    "type": "GrantOfRepresentation",
+	    "caseType": "intestacy",
+	    "applicationType": "Personal",
+	    "primaryApplicantEmailAddress": "jsnow@bbc.co.uk",
+	    "primaryApplicantForenames": "Jon",
+	    "primaryApplicantSurname": "Snow",
+	    "primaryApplicantAddress": {
+	      "AddressLine1": "Pret a Manger St. Georges Hospital Blackshaw Road London SW17 0QT"
+	    },
+	    "primaryApplicantFreeTextAddress": "Pret a Manger St. Georges Hospital Blackshaw Road",
+	    "primaryApplicantAddressFound": "Yes",
+	    "primaryApplicantPhoneNumber": "123455678",
+	    "primaryApplicantRelationshipToDeceased": "adoptedChild",
+	    "primaryApplicantAdoptionInEnglandOrWales": "Yes",
+	    "payments": [
+	        {
+	          "value": {
+	            "status": "Success",
+	            "date": "2018-12-03",
+	            "reference": "RC-1537-1988-5489-1985",
+	            "amount": "22050",
+	            "method": "online",
+	            "transactionId": "r23k178busa0rp2mh27m0vchja",
+	            "siteId": "P223"
+	          }
+	        }
+	      ],
+	    "deceasedForenames": "Ned",
+	    "deceasedSurname": "Stark",
+	    "deceasedDateOfBirth": "1930-01-01",
+	    "deceasedDateOfDeath": "2018-01-01",
+	    "deceasedAddress": {
+	      "AddressLine1": "Winterfell, Westeros"
+	    },
+	    "deceasedFreeTextAddress": "Winterfell, Westeros",
+	    "deceasedAddressFound": "Yes",
+	    "deceasedAnyOtherNames": "No",
+	    "deceasedAliasNameList": [
+	      {
+	        "value": {
+	          "Forenames": "King",
+	          "LastName": "North"
+	        }
+	      }
+	    ],
+	    "deceasedMartialStatus": "marriedCivilPartnership",
+	    "deceasedDivorcedInEnglandOrWales": "No",
+	    "deceasedSpouseNotApplyingReason": "mentallyIncapable",
+	    "deceasedOtherChildren": "Yes",
+	    "childrenOverEighteenSurvived": "Yes",
+	    "childrenDied": "No",
+	    "grandChildrenSurvivedUnderEighteen": "No",
+	    "deceasedAnyChildren": "No",
+	    "registryLocation": "Birmingham",
+	    "assetsOverseasNetValue": "10050",
+	    "deceasedHasAssetsOutsideUK": "Yes",
+	    "ihtFormId": "IHT205",
+	    "ihtFormCompletedOnline": "Yes",
+	    "ihtGrossValue": "100000",
+	    "ihtNetValue": "100000",
+	    "ihtReferenceNumber": "GOT123456",
+	    "declarationCheckbox": "Yes",
+	    "extraCopiesOfGrant": 5,
+	    "outsideUKGrantCopies": 6,
+	    "uploadDocumentUrl": "http://document-management/document/12345"
+	  },
+	  "caseInfo": {
+	    "caseId": "12323213323",
+	    "state": "PAAppCreated"
+	  }
+	}

--- a/src/test/resources/files/v2/payments.json
+++ b/src/test/resources/files/v2/payments.json
@@ -1,9 +1,0 @@
-{
-  "status": "Success",
-  "date": "2018-12-03",
-  "reference": "RC-1537-1988-5489-1985",
-  "amount": "22050",
-  "method": "online",
-  "transactionId": "r23k178busa0rp2mh27m0vchja",
-  "siteId": "P223"
-}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-5546

### Change description ###
Update to add payment callback for caveats. Code update a caveat stop application and sends email notification which is reported in the CCD case.

Please see PRO-5546 for more details including postman test data, although PR's will use GovPay scheduled service for initiating the callback.

**Does this PR introduce a breaking change?** (check one with "x")
This doesn't introduce a breaking change however for the functionality to be used PRO-5546 branches for probate-orchestrator-service, probate-caveats-frontend and probate-back-office also need to be pushed.

```
[ ] Yes
[x] No
```
