### PR TITLE
DTSPB-4761 Use azure artifacts rather than jitpack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ pitest {
 repositories {
     mavenLocal()
     mavenCentral()
-    maven { url "https://jitpack.io" }
+    maven { url 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1' }
 }
 
 def versions = [
@@ -178,9 +178,8 @@ def versions = [
         junitJupiter                    : '5.9.1',
         lombok                          : '1.18.38',
         logging                         : '6.1.9',
-        pact_version                    : '4.1.7',
-        probateCommons                  : '2.0.57',
-        probatePactCommonsVersion       : '1.0.2',
+        pact_version                    : '4.1.34',
+        probateCommons                  : '2.2.2',
         restAssured                     : '5.5.5',
         serenity                        : '4.2.30',
         serviceAuthProviderClient       : '5.3.2',
@@ -190,6 +189,7 @@ def versions = [
         springDocUi                     : '2.6.0',
         springSecurityTesting           : '6.5.0',
         springSecurityVersion           : '6.3.0',
+        fortifyClient                   : '1.4.9',
 ]
 
 dependencyManagement {
@@ -228,7 +228,7 @@ dependencies {
     testImplementation group: 'org.springframework.security', name: 'spring-security-test', version: versions.springSecurityTesting
     testImplementation group: 'org.springframework.cloud', name: 'spring-cloud-contract-wiremock', version: versions.springCloudWiremock
 
-    testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.8', classifier: 'all'
+    testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: versions.fortifyClient, classifier: 'all'
     testImplementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: versions.serviceAuthProviderClient
     testImplementation group: 'com.github.hmcts', name: 'auth-checker-lib', version: versions.authCheckerLib
     testImplementation group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
@@ -269,11 +269,12 @@ dependencies {
     testPactImplementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.12.6'
     testPactImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
     testPactImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junitJupiter
-    testPactImplementation group: 'com.github.hmcts', name: 'probate-pact-commons', version: versions.probatePactCommonsVersion
+    testPactImplementation group: 'com.github.hmcts', name: 'probate-pact-commons', version: versions.probateCommons
     testPactImplementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.5.0'
     testPactImplementation group: 'au.com.dius.pact.provider', name: 'junit5', version: versions.pact_version
     testPactImplementation group: 'au.com.dius.pact.provider', name: 'spring', version: versions.pact_version
     testPactImplementation group: 'au.com.dius.pact.consumer', name: 'junit5', version: versions.pact_version
+    testPactImplementation group: 'au.com.dius.pact.consumer', name: 'java8',  version: versions.pact_version
     testPactRuntimeOnly group: 'au.com.dius.pact.consumer', name: 'junit5', version: versions.pact_version
     testPactRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junitJupiter
     testPactRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.8.0-M1'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,2 +1,21 @@
-<?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until = "2025-10-15">
+        <!--
+            Pebble literal templates can permit loading from the filesystem.
+            If a user could control the template input this would be an issue,
+            but we only load templates through a classpath loaded, not using
+            a string loader, and the templates are managed from the resources
+            in probate-commons.
+        -->
+        <cve>CVE-2025-1686</cve>
+    </suppress>
+    <suppress until = "2025-10-15">
+        <!--
+            This has been pulled in transitively through pact-commons which is
+            only used by the pactTest handling and is not deployed in the
+            production environment.
+        -->
+        <cve>CVE-2022-23437</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION

This now flags an additional CVE - which is only present in the pactTest component, not production code so we are suppressing it.

### JIRA link (if applicable) ###
See [DTSPB-4761](https://tools.hmcts.net/jira/browse/DTSPB-4761)


### Change description ###
Removes the configuration to gather inputs from jitpack, adds azure artifacts.
Updates to use probate-pact-commons from the probate-commons repository (since its original repository was archived).

Adds two new CVE suppressions, both from dependencies introduced by commons/pact-commons:
- [CVE-2025-1686](https://nvd.nist.gov/vuln/detail/CVE-2025-1686) - if the `PebbleEngine::getLiteralTemplate(String)` method is used it can permit arbitrary file read. We do not use pebble within this repository (directly or indirectly)
- [CVE-2022-23437](https://nvd.nist.gov/vuln/detail/CVE-2022-23437) - used within the (now replaced upstream) pact dsl implementation. only used in pactTest handling during builds, not in deployed artifacts

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
