### PR TITLE
DTSPB-5046 lookup by id from ccd rather than searching in elastic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ bin/
 gradle-wrapper.jar
 gradlew.bat
 *.hprof
-
+.aat-env

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -19,7 +19,9 @@ def secrets = [
                 secret('probateIdamOauthRedirectUrl', 'IDAM_OAUTH2_REDIRECT_URI'),
                 secret('probate-service-id', 'IDAM_CLIENT_ID'),
                 secret('cwUserEmail', 'CW_USER_EMAIL'),
-                secret('cwUserPass', 'CW_USER_PASSWORD')
+                secret('cwUserPass', 'CW_USER_PASSWORD'),
+                secret('launchdarkly-key', 'LAUNCHDARKLY_KEY'),
+                secret('launchdarklyUserkeyBackend', 'LD_USER_KEY')
         ],
         's2s-${env}'      : [
                 secret('microservicekey-ccd-data', 'DATA_STORE_S2S_KEY'),

--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,7 @@ dependencies {
     implementation group: 'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: '1.15.0'
     implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '9.0'
     implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.2.3'
+    implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '7.10.2'
 
     //Solves CVE-2025-48989
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: versions.tomcat

--- a/charts/probate-submit-service/Chart.yaml
+++ b/charts/probate-submit-service/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for the HMCTS probate-submit product
 name: probate-submit-service
 home: https://github.com/hmcts/probate-submit-service
-version: 0.2.36
+version: 0.2.37
 maintainers:
   - name: HMCTS Probate Team
     email: probate-action-group@HMCTS.NET

--- a/charts/probate-submit-service/values.preview.template.yaml
+++ b/charts/probate-submit-service/values.preview.template.yaml
@@ -59,3 +59,11 @@ ccd-elasticsearch:
         - caseworker-probate-solicitor
         - citizen
         - caseworker-probate-examiner
+
+keyVaults:
+  probate:
+    secrets:
+      - name: launchdarkly-key
+        alias: ld.sdk_key
+      - name: launchdarklyUserkeyBackend
+        alias: ld.user.key

--- a/charts/probate-submit-service/values.yaml
+++ b/charts/probate-submit-service/values.yaml
@@ -34,6 +34,10 @@ java:
           alias: S2S_AUTH_TOTP_SECRET
         - name: app-insights-connection-string
           alias: app-insights-connection-string
+        - name: launchdarkly-key
+          alias: ld.sdk_key
+        - name: launchdarklyUserkeyBackend
+          alias: ld.user.key
   image: hmctspublic.azurecr.io/probate/probate-submit-service:latest
 
 

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/payments/GrantOfRepresentationPaymentTests.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/payments/GrantOfRepresentationPaymentTests.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.probate.functional.payments;
 import io.restassured.RestAssured;
 import net.serenitybdd.junit5.SerenityJUnit5Extension;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,7 +29,10 @@ public class GrantOfRepresentationPaymentTests extends IntegrationTestBase {
 
         paymentInitiatedData = utils.getJsonFromFile("gop.paymentInitiated.json");
         paymentSuccessData = utils.getJsonFromFile("gop.singleExecutor.full.json");
+    }
 
+    @BeforeEach
+    public void setUp() throws Exception {
         caseId = utils.createTestCase(caseData);
         Thread.sleep(SLEEP_TIME);
     }

--- a/src/functionalTest/java/uk/gov/hmcts/probate/functional/util/TestUtils.java
+++ b/src/functionalTest/java/uk/gov/hmcts/probate/functional/util/TestUtils.java
@@ -71,7 +71,7 @@ public class TestUtils {
             .assertThat()
             .statusCode(200)
             .extract().jsonPath();
-        return jsonPath.get("caseInfo.caseId");
+        return jsonPath.getString("caseInfo.caseId");
     }
 
     public String createCaveatTestCase(String caseData) {

--- a/src/functionalTest/resources/json/gop.singleExecutor.partial.json
+++ b/src/functionalTest/resources/json/gop.singleExecutor.partial.json
@@ -116,5 +116,7 @@
     "deceasedMarriedAfterWillOrCodicilDate": "No",
     "deceasedDiedEngOrWales": "Yes",
     "deceasedDeathCertificate": "deathCertificate"
+  },
+  "caseInfo": {
   }
 }

--- a/src/main/java/uk/gov/hmcts/probate/config/LDClientConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/probate/config/LDClientConfiguration.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.probate.config;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.LDClient;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LDClientConfiguration {
+    @Bean
+    public LDClientInterface ldClient(
+            @Value("${ld.sdk_key}") final String ldSdkKey) {
+        return new LDClient(ldSdkKey);
+    }
+
+    @Bean
+    public LDContext ldContext(
+            @Value("${ld.user.key}") final String ldUserKey,
+            @Value("${ld.user.firstName}") final String ldUserFirstName,
+            @Value("${ld.user.lastName}") final String ldUserLastName) {
+
+        final String contextName = new StringBuilder()
+                .append(ldUserFirstName)
+                .append(" ")
+                .append(ldUserLastName)
+                .toString();
+        return LDContext.builder(ldUserKey)
+                .name(contextName)
+                .kind("application")
+                .set("timestamp", String.valueOf(System.currentTimeMillis()))
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/core/FeatureToggleServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/core/FeatureToggleServiceImpl.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.probate.services.submit.core;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.probate.services.submit.services.FeatureToggleService;
+
+@Service
+@Slf4j
+public class FeatureToggleServiceImpl implements FeatureToggleService {
+    private final LDClientInterface ldClient;
+    private final LDContext ldContext;
+
+    public FeatureToggleServiceImpl(
+            final LDClientInterface ldClient,
+            final LDContext ldContext) {
+        this.ldClient = ldClient;
+        this.ldContext = ldContext;
+    }
+
+    private boolean isFeatureToggleOn(
+            final String featureToggleCode,
+            final boolean defaultValue) {
+        return this.ldClient.boolVariation(featureToggleCode, this.ldContext, defaultValue);
+    }
+
+    @Override
+    public boolean useCcdLookupForPayments() {
+        return isFeatureToggleOn("probate-use-ccd-lookup-not-elastic-when-paying", false);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/core/FeatureToggleServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/core/FeatureToggleServiceImpl.java
@@ -12,6 +12,8 @@ public class FeatureToggleServiceImpl implements FeatureToggleService {
     private final LDClientInterface ldClient;
     private final LDContext ldContext;
 
+    static final String PAYMENT_LOOKUP_FEATURE = "probate-use-ccd-lookup-not-elastic-when-paying";
+
     public FeatureToggleServiceImpl(
             final LDClientInterface ldClient,
             final LDContext ldContext) {
@@ -27,6 +29,6 @@ public class FeatureToggleServiceImpl implements FeatureToggleService {
 
     @Override
     public boolean useCcdLookupForPayments() {
-        return isFeatureToggleOn("probate-use-ccd-lookup-not-elastic-when-paying", false);
+        return isFeatureToggleOn(PAYMENT_LOOKUP_FEATURE, false);
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/core/FeatureToggleServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/core/FeatureToggleServiceImpl.java
@@ -6,12 +6,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.probate.services.submit.services.FeatureToggleService;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
 @Service
 @Slf4j
 public class FeatureToggleServiceImpl implements FeatureToggleService {
     private final LDClientInterface ldClient;
     private final LDContext ldContext;
 
+    private final AtomicBoolean cacheConfirmFeatureToggle;
+    private final AtomicInteger logLimit;
+
+    static final String CONFIRM_FEATURE = "probate-confirm-feature-toggle";
     static final String PAYMENT_LOOKUP_FEATURE = "probate-use-ccd-lookup-not-elastic-when-paying";
 
     public FeatureToggleServiceImpl(
@@ -19,6 +26,9 @@ public class FeatureToggleServiceImpl implements FeatureToggleService {
             final LDContext ldContext) {
         this.ldClient = ldClient;
         this.ldContext = ldContext;
+
+        this.cacheConfirmFeatureToggle = new AtomicBoolean(false);
+        this.logLimit = new AtomicInteger(0);
     }
 
     private boolean isFeatureToggleOn(
@@ -27,8 +37,21 @@ public class FeatureToggleServiceImpl implements FeatureToggleService {
         return this.ldClient.boolVariation(featureToggleCode, this.ldContext, defaultValue);
     }
 
+    void confirmFeatureToggle() {
+        final boolean confirmFeatureToggle = isFeatureToggleOn(CONFIRM_FEATURE, false);
+        final int currentLimit = logLimit.getAndIncrement();
+        if (cacheConfirmFeatureToggle.compareAndSet(!confirmFeatureToggle, confirmFeatureToggle)) {
+            log.info("confirmFeatureToggle is now {}, was previously inverted", confirmFeatureToggle);
+        } else {
+            if (currentLimit % 128 == 0) {
+                log.info("confirmFeatureToggle is {} (called {} times)", confirmFeatureToggle, currentLimit);
+            }
+        }
+    }
+
     @Override
     public boolean useCcdLookupForPayments() {
+        confirmFeatureToggle();
         return isFeatureToggleOn(PAYMENT_LOOKUP_FEATURE, false);
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/services/submit/services/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/probate/services/submit/services/FeatureToggleService.java
@@ -1,0 +1,5 @@
+package uk.gov.hmcts.probate.services.submit.services;
+
+public interface FeatureToggleService {
+    boolean useCcdLookupForPayments();
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -193,3 +193,10 @@ core_case_data.api.url: ${services.coreCaseData.baseUrl}
 springdoc:
   packagesToScan: uk.gov.hmcts.probate
   pathsToMatch: /**
+
+ld:
+  sdk_key: ${LAUNCHDARKLY_KEY:dummy}
+  user:
+    key: ${LD_USER_KEY:dummy_key}
+    firstName: Probate
+    lastName: Submit

--- a/src/pactTest/resources/application.yml
+++ b/src/pactTest/resources/application.yml
@@ -221,3 +221,9 @@
 
   core_case_data.api.url: http://localhost:4452
 
+  ld:
+    sdk_key: ${LAUNCHDARKLY_KEY:dummy}
+    user:
+      key: ${LD_USER_KEY:dummy_key}
+      firstName: Probate
+      lastName: Submit

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/core/FeatureToggleServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/core/FeatureToggleServiceImplTest.java
@@ -57,4 +57,13 @@ class FeatureToggleServiceImplTest {
                 anyBoolean());
         assertThat(actual, equalTo(expected));
     }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void coverConfirmFeatureToggleFalse(final boolean param) {
+        when(ldClientMock.boolVariation(eq(FeatureToggleServiceImpl.CONFIRM_FEATURE), eq(ldContextMock), anyBoolean()))
+                .thenReturn(param);
+
+        featureToggleService.confirmFeatureToggle();
+    }
 }

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/core/FeatureToggleServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/core/FeatureToggleServiceImplTest.java
@@ -11,7 +11,6 @@ import org.mockito.MockitoAnnotations;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -44,12 +43,18 @@ class FeatureToggleServiceImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void lookupFromLDWhenCcdPaymentQueried(final boolean expected) {
-        when(ldClientMock.boolVariation(any(), eq(ldContextMock), anyBoolean()))
+        when(ldClientMock.boolVariation(
+                    eq(FeatureToggleServiceImpl.PAYMENT_LOOKUP_FEATURE),
+                    eq(ldContextMock),
+                    anyBoolean()))
                 .thenReturn(expected);
 
         final boolean actual = featureToggleService.useCcdLookupForPayments();
 
-        verify(ldClientMock).boolVariation(any(), eq(ldContextMock), anyBoolean());
+        verify(ldClientMock).boolVariation(
+                eq(FeatureToggleServiceImpl.PAYMENT_LOOKUP_FEATURE),
+                eq(ldContextMock),
+                anyBoolean());
         assertThat(actual, equalTo(expected));
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/services/submit/core/FeatureToggleServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/services/submit/core/FeatureToggleServiceImplTest.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.probate.services.submit.core;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class FeatureToggleServiceImplTest {
+    @Mock
+    LDClientInterface ldClientMock;
+    @Mock
+    LDContext ldContextMock;
+
+    FeatureToggleServiceImpl featureToggleService;
+
+    AutoCloseable closeableMocks;
+
+    @BeforeEach
+    void setUp() {
+        closeableMocks = MockitoAnnotations.openMocks(this);
+
+        featureToggleService = new FeatureToggleServiceImpl(
+                ldClientMock,
+                ldContextMock);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeableMocks.close();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void lookupFromLDWhenCcdPaymentQueried(final boolean expected) {
+        when(ldClientMock.boolVariation(any(), eq(ldContextMock), anyBoolean()))
+                .thenReturn(expected);
+
+        final boolean actual = featureToggleService.useCcdLookupForPayments();
+
+        verify(ldClientMock).boolVariation(any(), eq(ldContextMock), anyBoolean());
+        assertThat(actual, equalTo(expected));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
See [DTSPB-5046](https://tools.hmcts.net/jira/browse/DTSPB-5046)


### Change description ###
amends behaviour in PaymentServiceImpl to use the direct lookup from CCD since if we are at the point where we are paying for a case it should already exist. if it doesn't we're going to have a weird time, but that was already the case (unless something is shoving fake case data into ES


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
